### PR TITLE
Announcement 엔드포인트 제공 (Admin 모듈 생성)

### DIFF
--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -1,0 +1,21 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+
+class MockAdminService {}
+describe('AdminController', () => {
+  let controller: AdminController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [{ provide: AdminService, useClass: MockAdminService }],
+    }).compile();
+
+    controller = module.get<AdminController>(AdminController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminService } from './admin.service';
+import { AnnoumcementDto } from './dto/announcement.dto';
+
+@ApiTags('admin')
+@Controller('api/admin')
+export class AdminController {
+  constructor(private adminService: AdminService) {}
+
+  @ApiOkResponse({
+    description: '공지사항 목력 출력',
+    type: AnnoumcementDto,
+    isArray: true,
+  })
+  @ApiOperation({ summary: '공지사항 확인' })
+  @Get('/announcement')
+  getAnnouncement() {
+    return this.adminService.getAnnouncement();
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Announcement } from 'src/entities/Announcement';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Announcement])],
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Announcement } from 'src/entities/Announcement';
+import { Connection } from 'typeorm';
+import { AdminService } from './admin.service';
+
+const mockAnnouncementRepository = () => ({
+  save: jest.fn(),
+  find: jest.fn(),
+  findOne: jest.fn(),
+  softDelete: jest.fn(),
+});
+
+const mockConnection = () => ({
+  transaction: jest.fn(),
+});
+
+describe('AdminService', () => {
+  let service: AdminService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        {
+          provide: getRepositoryToken(Announcement),
+          useValue: mockAnnouncementRepository(),
+        },
+        {
+          provide: Connection,
+          useFactory: mockConnection,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Announcement } from 'src/entities/Announcement';
+import { Connection, Repository } from 'typeorm';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    @InjectRepository(Announcement)
+    private announcementRepository: Repository<Announcement>,
+    private connection: Connection,
+  ) {}
+
+  getAnnouncement() {
+    return this.announcementRepository.find();
+  }
+}

--- a/src/admin/dto/announcement.dto.ts
+++ b/src/admin/dto/announcement.dto.ts
@@ -1,0 +1,3 @@
+import { Announcement } from 'src/entities/Announcement';
+
+export class AnnoumcementDto extends Announcement {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './auth/auth.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UserModule } from './user/user.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { UserModule } from './user/user.module';
       rootPath: join(__dirname, '..', 'profile_image'),
       serveRoot: '/profile_image',
     }),
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/database/announcement-temp.ts
+++ b/src/database/announcement-temp.ts
@@ -1,0 +1,126 @@
+// ref:
+//    https://www.lipsum.com/feed/html
+//    http://guny.kr/stuff/klorem/
+
+const loremIpsumOne: any =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
+  ' Mauris at tortor dapibus, elementum lectus vel, ornare augue.' +
+  ' In vel porttitor diam.' +
+  ' Aliquam vitae pharetra purus, sed volutpat tortor.' +
+  ' Nulla consectetur libero finibus, bibendum felis ut, rutrum lacus.' +
+  ' Phasellus finibus nec turpis eu lacinia. Fusce id elementum eros, et efficitur nibh.' +
+  ' Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
+  ' Curabitur quis consequat nunc, sit amet efficitur magna.' +
+  ' Phasellus arcu diam, facilisis fringilla ex sit amet, lacinia congue nisl.' +
+  ' Aliquam gravida, eros vel feugiat aliquam, lacus justo aliquet tellus, eget volutpat nibh felis quis turpis.';
+const loremIpsumTwo: any =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
+  ' Mauris at tortor dapibus, elementum lectus vel, ornare augue.' +
+  ' In vel porttitor diam.' +
+  ' Aliquam vitae pharetra purus, sed volutpat tortor.' +
+  ' Nulla consectetur libero finibus, bibendum felis ut, rutrum lacus.' +
+  ' Phasellus finibus nec turpis eu lacinia. Fusce id elementum eros, et efficitur nibh.' +
+  ' Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
+  ' Curabitur quis consequat nunc, sit amet efficitur magna.' +
+  ' Phasellus arcu diam, facilisis fringilla ex sit amet, lacinia congue nisl.' +
+  ' Aliquam gravida, eros vel feugiat aliquam, lacus justo aliquet tellus, eget volutpat nibh felis quis turpis.' +
+  '\n' +
+  'Nulla facilisi.' +
+  ' Fusce justo eros, aliquet a molestie eget, iaculis vitae tortor.' +
+  ' Fusce consectetur molestie sodales.' +
+  ' Maecenas in malesuada felis.' +
+  ' Nulla facilisi.' +
+  ' Praesent at urna at nulla aliquet volutpat.' +
+  ' Nam sed mauris metus.' +
+  ' Fusce tincidunt tellus condimentum sem interdum, malesuada vehicula leo tempus.' +
+  ' Integer posuere posuere mauris id bibendum.' +
+  ' Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.' +
+  ' Curabitur venenatis bibendum sapien.' +
+  ' Proin sagittis purus vel turpis commodo euismod.';
+
+const loremIpsumThree: any =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
+  ' Mauris at tortor dapibus, elementum lectus vel, ornare augue.' +
+  ' In vel porttitor diam.' +
+  ' Aliquam vitae pharetra purus, sed volutpat tortor.' +
+  ' Nulla consectetur libero finibus, bibendum felis ut, rutrum lacus.' +
+  ' Phasellus finibus nec turpis eu lacinia. Fusce id elementum eros, et efficitur nibh.' +
+  ' Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
+  ' Curabitur quis consequat nunc, sit amet efficitur magna.' +
+  ' Phasellus arcu diam, facilisis fringilla ex sit amet, lacinia congue nisl.' +
+  ' Aliquam gravida, eros vel feugiat aliquam, lacus justo aliquet tellus, eget volutpat nibh felis quis turpis.' +
+  '\n' +
+  'Nulla facilisi.' +
+  ' Fusce justo eros, aliquet a molestie eget, iaculis vitae tortor.' +
+  ' Fusce consectetur molestie sodales.' +
+  ' Maecenas in malesuada felis.' +
+  ' Nulla facilisi.' +
+  ' Praesent at urna at nulla aliquet volutpat.' +
+  ' Nam sed mauris metus.' +
+  ' Fusce tincidunt tellus condimentum sem interdum, malesuada vehicula leo tempus.' +
+  ' Integer posuere posuere mauris id bibendum.' +
+  ' Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.' +
+  ' Curabitur venenatis bibendum sapien.' +
+  ' Proin sagittis purus vel turpis commodo euismod.' +
+  '\n' +
+  'Fusce id condimentum quam.' +
+  ' Morbi auctor felis et tellus maximus accumsan.' +
+  ' Quisque consectetur sem orci, sed sodales eros mattis eget.' +
+  ' Nulla eros dui, venenatis tempor erat non, varius fringilla est.' +
+  ' Sed nec pharetra tortor.' +
+  ' Vivamus ut pellentesque lacus, in aliquam tellus.' +
+  ' Aliquam risus diam, ultricies id metus sed, convallis volutpat tellus.' +
+  ' Nam dolor ligula, sagittis in libero imperdiet, placerat fermentum magna.' +
+  ' Donec pharetra dolor a felis sollicitudin, nec mattis ante cursus.' +
+  ' Duis bibendum turpis sed nulla dictum porttitor.' +
+  ' Integer mattis mi ac tellus pulvinar porttitor.' +
+  ' Integer suscipit ex non lectus tempor pharetra.' +
+  ' Sed posuere lectus ac mi condimentum, sit amet elementum enim hendrerit.' +
+  ' Nulla facilisi.' +
+  ' Morbi a libero maximus, pretium risus ac, euismod leo.' +
+  ' Suspendisse efficitur quis turpis in tincidunt.';
+
+const koreanTempOne: any =
+  '국가의 세입·세출의 결산, 국가 및 법률이 정한 단체의 회계검사와 행정기관 및 공무원의 직무에 관한 감찰을 하기 위하여 대통령 소속하에 감사원을 둔다.' +
+  '\n' +
+  '국군은 국가의 안전보장과 국토방위의 신성한 의무를 수행함을 사명으로 하며, 그 정치적 중립성은 준수된다.';
+const koreanTempTwo: any =
+  '헌법에 의하여 체결·공포된 조약과 일반적으로 승인된 국제법규는 국내법과 같은 효력을 가진다. ' +
+  '비상계엄하의 군사재판은 군인·군무원의 범죄나 군사에 관한 간첩죄의 경우와 초병·초소·유독음식물공급·포로에 관한 죄중 법률이 정한 경우에 한하여 단심으로 할 수 있다. ' +
+  '다만, 사형을 선고한 경우에는 그러하지 아니하다.' +
+  '\n' +
+  '\n' +
+  '모든 국민은 거주·이전의 자유를 가진다. ' +
+  '언론·출판에 대한 허가나 검열과 집회·결사에 대한 허가는 인정되지 아니한다. ' +
+  '감사원은 세입·세출의 결산을 매년 검사하여 대통령과 차년도국회에 그 결과를 보고하여야 한다. ' +
+  '\n' +
+  '\n' +
+  '국가유공자·상이군경 및 전몰군경의 유가족은 법률이 정하는 바에 의하여 우선적으로 근로의 기회를 부여받는다. ' +
+  '국가는 지역간의 균형있는 발전을 위하여 지역경제를 육성할 의무를 진다.';
+
+const koreanTempThree: any =
+  '헌법개정안은 국회가 의결한 후 30일 이내에 국민투표에 붙여 국회의원선거권자 과반수의 투표와 투표자 과반수의 찬성을 얻어야 한다. ' +
+  ' 대한민국의 경제질서는 개인과 기업의 경제상의 자유와 창의를 존중함을 기본으로 한다. ' +
+  ' 정기회의 회기는 100일을, 임시회의 회기는 30일을 초과할 수 없다. ' +
+  ' 각급 선거관리위원회의 조직·직무범위 기타 필요한 사항은 법률로 정한다. ' +
+  ' 비상계엄이 선포된 때에는 법률이 정하는 바에 의하여 영장제도, 언론·출판·집회·결사의 자유, 정부나 법원의 권한에 관하여 특별한 조치를 할 수 있다. ' +
+  ' 군인 또는 군무원이 아닌 국민은 대한민국의 영역안에서는 중대한 군사상 기밀·초병·초소·유독음식물공급·포로·군용물에 관한 죄중 법률이 정한 경우와 비상계엄이 선포된 경우를 제외하고는 군사법원의 재판을 받지 아니한다.' +
+  '\n' +
+  '\n' +
+  '선거에 관한 경비는 법률이 정하는 경우를 제외하고는 정당 또는 후보자에게 부담시킬 수 없다. ' +
+  '국회의원이 회기전에 체포 또는 구금된 때에는 현행범인이 아닌 한 국회의 요구가 있으면 회기중 석방된다. ' +
+  '국회의원의 선거구와 비례대표제 기타 선거에 관한 사항은 법률로 정한다. ' +
+  '국회의원은 국가이익을 우선하여 양심에 따라 직무를 행한다. ' +
+  '국군의 조직과 편성은 법률로 정한다. ' +
+  '위원은 정당에 가입하거나 정치에 관여할 수 없다. ' +
+  '모든 국민은 그 보호하는 자녀에게 적어도 초등교육과 법률이 정하는 교육을 받게 할 의무를 진다. ' +
+  '누구든지 체포 또는 구속을 당한 때에는 적부의 심사를 법원에 청구할 권리를 가진다.';
+
+export {
+  loremIpsumOne,
+  loremIpsumTwo,
+  loremIpsumThree,
+  koreanTempOne,
+  koreanTempTwo,
+  koreanTempThree,
+};

--- a/src/database/seeds/announcement-initial-data.ts
+++ b/src/database/seeds/announcement-initial-data.ts
@@ -1,0 +1,56 @@
+import { Announcement } from 'src/entities/Announcement';
+import { Connection } from 'typeorm';
+import { Factory, Seeder } from 'typeorm-seeding';
+import {
+  koreanTempOne,
+  koreanTempThree,
+  koreanTempTwo,
+  loremIpsumOne,
+  loremIpsumTwo,
+  loremIpsumThree,
+} from '../announcement-temp';
+
+export class AnnouncementInitialData implements Seeder {
+  public async run(factory: Factory, connection: Connection): Promise<any> {
+    await connection
+      .createQueryBuilder()
+      .insert()
+      .into(Announcement)
+      .values([
+        {
+          adminId: 1,
+          title: '공지사항 제목 1',
+          content: loremIpsumOne,
+        },
+        {
+          adminId: 1,
+          title: '공지사항 제목 2 공지사항 제목 2',
+          content: loremIpsumTwo,
+        },
+        {
+          adminId: 2,
+          title: '공지사항 제목 3 공지사항 제목 3 공지사항 제목 3',
+          content: loremIpsumThree,
+        },
+        {
+          adminId: 3,
+          title:
+            '공지사항 제목 4 공지사항 제목 4 공지사항 제목 4 공지사항 제목 4',
+          content: koreanTempOne,
+        },
+        {
+          adminId: 2,
+          title:
+            '공지사항 제목 5 공지사항 제목 5 공지사항 제목 5 공지사항 제목 5 공지사항 제목 5',
+          content: koreanTempTwo,
+        },
+        {
+          adminId: 2,
+          title:
+            '공지사항 제목 6 공지사항 제목 6 공지사항 제목 6 공지사항 제목 6 공지사항 제목 6 공지사항 제목 6',
+          content: koreanTempThree,
+        },
+      ])
+      .execute();
+  }
+}

--- a/src/entities/Announcement.ts
+++ b/src/entities/Announcement.ts
@@ -1,0 +1,67 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('announcement')
+export class Announcement {
+  @ApiProperty({
+    description: '공지사항 아이디 번호 (순번)',
+    example: 1,
+  })
+  @PrimaryGeneratedColumn({ type: 'int', name: 'announcement_id' })
+  announcementId: number;
+
+  @ApiProperty({
+    description: '작성자(관리자) ID',
+    example: 1,
+    required: true,
+  })
+  @Column({ type: 'int', name: 'admin_id' })
+  adminId: number;
+
+  @ApiProperty({
+    description: '제목',
+    example: '[이벤트] 지금 게임 하시면 별이 다섯개!',
+    required: true,
+  })
+  @Column('varchar', { name: 'title', length: 100 })
+  title: string;
+
+  @ApiProperty({
+    description: '공지사항 내용',
+    required: true,
+  })
+  @Column({ type: 'text', name: 'content' })
+  content: string;
+
+  @ApiProperty({
+    description: '공지사항 생성 일시',
+    readOnly: true,
+  })
+  @CreateDateColumn({ name: 'created_at' })
+  readonly createdAt: Date;
+
+  @ApiProperty({
+    description: '공지사항 수정 일시',
+    readOnly: true,
+  })
+  @UpdateDateColumn({ name: 'last_modified_at' })
+  readonly lastModifiedAt: Date;
+
+  @ApiProperty({
+    description: '유저 삭제 일시',
+    readOnly: true,
+    default: null,
+  })
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date;
+
+  @Column({ name: 'is_deleted', type: 'boolean', default: false })
+  isDeleted: boolean;
+}


### PR DESCRIPTION
https://github.com/innercircle-byebye/ft_transcendence/discussions/27#discussion-3623048
에 따른 'api/admin/announcement' 엔드포인트를 구성하였습니다.

- 추후 실제 admin 모듈 생성시 응답 데이터의 스키마가 변경될 수 있다는 점을 전달하였습니다.
- 간단한 공지사항 확인용으로 총 6개의 공지사항 더미데이터를 전달합니다.
- 코드는 최소한의 module, controller, service를 이용하였습니다.

**리뷰 없이 merge 진행합니다**

close: #37 