### PR TITLE
fix: userService.registerUser 호출할때 email, nickname 잘못된 순서 고침

### DIFF
--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -102,16 +102,16 @@ export class UserController {
     if (file === undefined) {
       return this.userService.registerUser(
         req.user.userId,
-        formData.nickname,
         formData.email,
+        formData.nickname,
         req.user.imagePath,
       );
     }
     // TODO: production 환경 일 경우
     return this.userService.registerUser(
       req.user.userId,
-      formData.nickname,
       formData.email,
+      formData.nickname,
       `http://localhost:3005/profile_image/${file.filename}`,
     );
   }


### PR DESCRIPTION
userService.registerUser 함수 호출할때 email, nickname 순서 반대로 들어가있어서 변경하였습니다!

close #41 