### PR TITLE
전체 채널 목록 조회시 사용자 인원 확인 기능 추가

### DIFF
--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -34,7 +34,6 @@ export class ChannelService {
         if (channelList.password === null) channelList.isPrivate = false;
         else channelList.isPrivate = true;
         delete channelList.password;
-        console.log(channelList.name);
         channelList.currentChatMemberCount =
           await this.getCurrentChannelMemberCount(channelList.name);
         return channelList;

--- a/src/channel/dto/channel.dto.ts
+++ b/src/channel/dto/channel.dto.ts
@@ -1,4 +1,17 @@
-import { OmitType } from '@nestjs/swagger';
+import { ApiProperty, OmitType } from '@nestjs/swagger';
 import { Channel } from 'src/entities/Channel';
 
-export class ChannelDto extends OmitType(Channel, ['password']) {}
+export class ChannelDto extends OmitType(Channel, ['password']) {
+  @ApiProperty({
+    type: 'boolean',
+    description: '개설된 방의 공개 여부',
+  })
+  isPrivate: boolean;
+
+  @ApiProperty({
+    type: 'number',
+    description: '현재 채널에 참여중인 유저 명수',
+    example: 42,
+  })
+  currentChatMemberCount: number;
+}


### PR DESCRIPTION
front에서 온 요청사항으로 전체 채널 조회시 현재 채널에 참여한 인원수를 확인하도록 API 응답을 변경 하였습니다.

기능 구현시 기존 getChannelMembers 의 결과 object 의 length 를 사용하는 방식에서,

getCurrentChannelMemberCount 함수를 이용해, DB에 현재 채널 인원 을 COUNT(getCount() 사용) 처리 하는 함수를 만들어 이용하였습니다.

(해당 브랜치에 추가로 channel 응답 DTO에 isPrivate, currentChannelMemberCount 를 표기하도록 업데이트 하였습니다)

close #70 