### PR TITLE
passport 라이브러리 버전 다운그레이드

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express": "^4.17.1",
     "multer": "^1.4.3",
     "otplib": "^12.0.1",
-    "passport": "^0.5.0",
+    "passport": "^0.4.0",
     "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.0",
     "passport-oauth2": "^1.6.1",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46742040/139200431-00c22cae-fbb8-41cd-81a2-7ab63a022bb7.png)


해당 이슈는 `@nestjs/passport` 의 passport 버전 dependency와 맞지 않아서 생긴 문제였습니다. 백엔드 레포에서 해당 라이브러리 dependency 내리는 작업 진행 하고, 메인 레포의 [setup-develop-env](https://github.com/innercircle-byebye/ft_transcendence/commits/setup-develop-env) 브랜치에서 package-lock.json을 제외 시키는 처리도 진행하였습니다