### PR TITLE
Admin 페이지 과제 요구사항에 맞게 수정

### DIFF
--- a/src/entities/Announcement.ts
+++ b/src/entities/Announcement.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  BaseEntity,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -13,7 +14,7 @@ import { IAdmin } from './interfaces/IAdmin';
 import { IAnnouncement } from './interfaces/IAnnouncement';
 
 @Entity('announcement')
-export class Announcement implements IAnnouncement {
+export class Announcement extends BaseEntity implements IAnnouncement {
   @ApiProperty({
     description: '공지사항 아이디 번호 (순번)',
     example: 1,

--- a/src/entities/ChannelChat.ts
+++ b/src/entities/ChannelChat.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  BaseEntity,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -14,7 +15,7 @@ import { IChannelChat } from './interfaces/IChannelChat';
 import { IUser } from './interfaces/IUser';
 
 @Entity('channel_chat')
-export class ChannelChat implements IChannelChat {
+export class ChannelChat extends BaseEntity implements IChannelChat {
   @ApiProperty({
     description: '채널 내 채팅 id 번호 (사용자 메세지)',
     example: 1,

--- a/src/entities/ChannelMember.ts
+++ b/src/entities/ChannelMember.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  BaseEntity,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -14,7 +15,7 @@ import { IChannelMember } from './interfaces/IChannelMember';
 import { IUser } from './interfaces/IUser';
 
 @Entity('channel_member')
-export class ChannelMember implements IChannelMember {
+export class ChannelMember extends BaseEntity implements IChannelMember {
   @ApiProperty({
     description: '유저 ID 번호',
     example: 1,

--- a/src/entities/Friend.ts
+++ b/src/entities/Friend.ts
@@ -1,5 +1,4 @@
 import {
-  BaseEntity,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -18,7 +17,7 @@ export enum FriendStatus {
 }
 
 @Entity('friend')
-export class Friend extends BaseEntity {
+export class Friend {
   @PrimaryGeneratedColumn({ type: 'int', name: 'friend_id' })
   friendId: number;
 

--- a/src/entities/GameMember.ts
+++ b/src/entities/GameMember.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  BaseEntity,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -21,7 +20,7 @@ export enum GameMemberStatus {
 }
 
 @Entity('game_member')
-export class GameMember extends BaseEntity implements IGameMember {
+export class GameMember implements IGameMember {
   @ManyToOne('GameRoom', 'gameMembers', { primary: true })
   @JoinColumn({ name: 'game_room_id' })
   gameRoom: IGameRoom;

--- a/src/entities/GameResult.ts
+++ b/src/entities/GameResult.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  BaseEntity,
   Column,
   Entity,
   JoinColumn,
@@ -18,7 +17,7 @@ export enum BallSpeed {
   SLOW = 'slow',
 }
 @Entity('game_result')
-export class GameResult extends BaseEntity implements IGameResult {
+export class GameResult implements IGameResult {
   @ApiProperty({
     description: '게임 결과 ID 번호',
     example: 1,

--- a/src/entities/GameRoom.ts
+++ b/src/entities/GameRoom.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  BaseEntity,
   Column,
   CreateDateColumn,
   DeleteDateColumn,
@@ -14,7 +13,7 @@ import { IGameResult } from './interfaces/IGameResult';
 import { IGameRoom } from './interfaces/IGameRoom';
 
 @Entity('game_room')
-export class GameRoom extends BaseEntity implements IGameRoom {
+export class GameRoom implements IGameRoom {
   @ApiProperty({
     description: '게임 방 ID번호',
     example: 1,


### PR DESCRIPTION
예전에 작성 해 놓은 브랜치입니다

admin 페이지에서 과제 요구사항에 맞는 테이블에 접근 할 수 있는 테이블들만 적어 놓았습니다.

* 과제 요구사항
- Admin 임명, 해제
- 채널 삭제
- 사용자 삭제
- 전체 채널 챗 확인
- 채널 관리자 임명/해제

위 기준을 맞출 수 있는 테이블 `Admin, User, Channel, ChannelMember, ChannelChat` 4가지의 테이블을 추가 해 놓았고, 추가적으로 `Announcement` 테이블을 추가 하였습니다.

- 사용 하지 않는 Admin 관련 엔드포인트를 삭제 할지 논의가 필요합니다. 