### PR TITLE
채널 초대시 채널 ID -> DM 전송하는 형태로 변경

### DIFF
--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -152,7 +152,7 @@ export class ChannelService {
     this.dmService.createDMs(
       ownerId,
       invitedUsers,
-      channelReturned.channelId.toString(),
+      name,
       DMType.CHANNEL_INVITE,
     );
 


### PR DESCRIPTION
`POST /api/channel/{name}/invite` 엔드포인트를 사용할때 전달되는 DM 메세지에서 채널 ID가 전달되는 부분을 채널 메세지가 전달되는 형태로 변경하였습니다.