### PR TITLE
프로덕션 환경 개선용 패키지 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "nest start",
     "start:dev": "nest build --webpack --webpackPath webpack-hmr.config.js --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "ts-node -r tsconfig-paths/register ./node_modules/typeorm-seeding/dist/cli.js seed  --configName ./src/ormconfig.ts ; node dist/main",
+    "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
현재 프로젝트에서 develop환경에서만 사용 되고 있던 패키지들이 production에서도 사용 되고 있고, 패키지 의존성 간 충돌 문제가 발생하여 아래 수정사항을 `package.json`에 반영하였습니다.

- passport 0.5.0 -> 0.4.0 다운그레이드
- nestjs-cli 패키지 devDependencies -> dependencies 이동 필요
- @types/*** 관련 패키지 devDependencies -> dependencies 이동 필요
- `npm run start:prod` 실행 단계 수정
  - 이전: `node dist/main`
  - 이후: `npm run seed:run` -> `node dist/main` 

close #128 