### PR TITLE
게임 결과(history) 검색 시간 offset 설정

### DIFF
--- a/src/game/game.service.ts
+++ b/src/game/game.service.ts
@@ -891,7 +891,9 @@ export class GameService {
     if (date && !Number.isNaN(new Date(date).getTime())) {
       const startDate = new Date(date);
       const endDate = new Date(date);
-      endDate.setHours(endDate.getHours() + 23);
+      console.log(startDate.getTimezoneOffset());
+      startDate.setHours(startDate.getHours() - 9);
+      endDate.setHours(endDate.getHours() + 14);
       endDate.setMinutes(endDate.getMinutes() + 59);
       endDate.setSeconds(endDate.getSeconds() + 59);
       console.log(startDate, endDate);


### PR DESCRIPTION
(맨 아래 두줄 분수, 검색 시간범위 참고해주세요)
![image](https://user-images.githubusercontent.com/46742040/141754221-3db4a60a-dbfd-4e8a-8905-f34f7246ff3d.png)


위 이미지와 같이 검색 시간의 범위를 변경하여 적용하였습니다.

현재 모든 서버시간은 `Asia/Seoul`로 통일 되어있습니다. (프론트, 백, DB 전부)

여기에서 검색시 전달되는 일자를 바탕으로 새로운 Date 객체를 생성하게되면 UTC 기준으로 Date를 생성하게됩니다.

여기에 현재 서버시간의 offset인 9시간을 빼 준 값을 검색 기준에 반영하였습니다.