### PR TITLE
사이트에 접속중인 사용자를 알수있는 onlineList 이벤트 추가 

### DIFF
--- a/src/events/main-events.gateway.ts
+++ b/src/events/main-events.gateway.ts
@@ -15,6 +15,9 @@ export class MainEventsGateway implements OnGatewayDisconnect {
 
   handleDisconnect(@ConnectedSocket() socket: Socket) {
     delete onlineMap[socket.id];
+    const onlineSet = new Set(Object.values(onlineMap));
+    const uniqueOnlineList = [...onlineSet];
+    socket.nsp.emit('onlineList', uniqueOnlineList);
   }
 
   @SubscribeMessage('login')
@@ -23,6 +26,8 @@ export class MainEventsGateway implements OnGatewayDisconnect {
     @ConnectedSocket() socket: Socket,
   ) {
     onlineMap[socket.id] = userId;
-    socket.nsp.emit('onlineList', Object.values(onlineMap));
+    const onlineSet = new Set(Object.values(onlineMap));
+    const uniqueOnlineList = [...onlineSet];
+    socket.nsp.emit('onlineList', uniqueOnlineList);
   }
 }


### PR DESCRIPTION
현재 접속중인 사용자id리스트를 전달해주는 onlineList 이벤트를 추가하였습니다. 

- 이벤트명 : 'onlineList'
- 대상 : main 네임스페이스 전체(현재 사이트에 접속중인 모두)
- 데이터 : 접속중인 유저아이디 목록 (number 배열) (중복없고, 정렬은 되어있지 않음)