### PR TITLE
채널 사용자 조회 쿼리 수정

### DIFF
--- a/src/channel/channel.service.ts
+++ b/src/channel/channel.service.ts
@@ -8,7 +8,7 @@ import { ChannelMember } from 'src/entities/ChannelMember';
 import { DMType } from 'src/entities/DM';
 import { User } from 'src/entities/User';
 import { ChatEventsGateway } from 'src/events/chat-events.gateway';
-import { Connection, MoreThan, Repository } from 'typeorm';
+import { Brackets, Connection, MoreThan, Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 
 // TODO: 채널 조회시 비밀방 유무로 객체 전달
@@ -263,7 +263,13 @@ export class ChannelService {
       .innerJoinAndSelect('channelMembers.user', 'user')
       .select(['channelMembers', 'user.nickname', 'user.imagePath'])
       .withDeleted()
-      .addSelect('channelMember.banDate is not null')
+      .andWhere(
+        new Brackets((qb) => {
+          qb.where('channelMembers.deletedAt is null').orWhere(
+            'channelMembers.banDate is not null',
+          );
+        }),
+      )
       .getMany();
   }
 


### PR DESCRIPTION
채널 사용자 조회시 `ban 사용자` 조회를 위해 .withDeleted() 함수를 호출 하던 부분에서, 채널을 나간 사용자와 ban 당한 사용자를 조회하는 쿼리함수를 적용하였습니다.