### PR TITLE
onlineList( client->server) 이벤트 추가

### DIFF
--- a/src/events/main-events.gateway.ts
+++ b/src/events/main-events.gateway.ts
@@ -38,6 +38,19 @@ export class MainEventsGateway implements OnGatewayDisconnect {
     this.server.to(socket.id).emit('playerList', playerListData);
   }
 
+  @SubscribeMessage('onlineList')
+  handleOnlineList(@ConnectedSocket() socket: Socket) {
+    const onlineSet = new Set(Object.values(onlineMap));
+    const uniqueOnlineList = [...onlineSet];
+    this.server.to(socket.id).emit('onlineList', uniqueOnlineList);
+
+    const playerListData = {
+      player1: Array.from(playerSets.player1),
+      player2: Array.from(playerSets.player2),
+    };
+    this.server.to(socket.id).emit('playerList', playerListData);
+  }
+
   emitPlayerList() {
     const emitData = {
       player1: Array.from(playerSets.player1),


### PR DESCRIPTION
프론트에서 접속중인 사용자 정보, 게임중인 사용자 정보를 원할 때마다 받을 수 있도록 'onlineList' 이벤트(clinet-> server)를 추가하였습니다.
(서버는 'onlineList' 이벤트를 받으면, 클라이언트에게 기존과 동일한 'onlineList', 'playerList' 이벤트를 보냅니다.)

close #145 