### PR TITLE
랭크 조회 쿼리 수정(가장 가까운 값 행 여러개 중 순서 정렬 후 위 1개로 저장)

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -59,7 +59,6 @@ export class UserService {
     const targetUser: any = await this.userRepository
       .createQueryBuilder('user')
       .where('user.nickname = :nickname', { nickname })
-      .limit(1)
       .getOne();
 
     if (!targetUser) {


### PR DESCRIPTION
게임 랭크데이터 조회시 findOne / lessthanorequalto 로 조회 하던 방식에 오류가 있어 새로운 querybuilder를 작성하여 수정하였습니다.